### PR TITLE
Remove Morocco Microsoft Community from event

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,6 @@
 
 - [Devoxx Morocco](https://devoxx.ma/)
 - [ForLoop Morocco](https://twitter.com/forloopmorocco)
-- [Morocco Microsoft Community](http://www.moroccomicrosoftcommunity.com/Event)
 
 ---
 


### PR DESCRIPTION
Morocco Microsoft Community is more of a community organizing meetups! Events are basically conferences